### PR TITLE
Don’t apply redirects to language subbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,18 @@ Each object in the `redirects` array has 2 important keys: `from` and `to`.
 
 
 This will create the pages `oldpage.html` and `olddir/oldpage.html` in the output and they will redirect to `/newpage.html` and `/newdir/newpage.html` respectively.
+
+Folder redirect also possible:
+
+```json
+{
+    "redirects": [
+        {
+            "from": "somepage/",
+            "to": "somepage.html"
+        }
+    ]
+}
+```
+
+This will create a page `somepage/index.html`, that will redirect to `somepage.html`.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Configuration for this plugin is specified in `book.json` in the `pluginsConfig`
 "pluginsConfig": {
     "bulk-redirect": {
         "basepath": "/",
+        "blank": false,
         "redirectsFile": "redirects.json"
     }
 }
@@ -44,10 +45,13 @@ If the book is hosted at the root of the domain, e.g. `http://example.com/`, the
 }
 ```
 
+### blank
 
-### `redirects` in redirects.json 
+Setting this parameter to true will leave your redirect pages blank and untitled (no "Click here if you are not redirected" link).
 
-The `redirects` contains an array of objects. This array should be present in another file. This relative path of this file should be passed in the `redirectsFile` field.  
+### `redirects` in redirects.json
+
+The `redirects` contains an array of objects. This array should be present in another file. This relative path of this file should be passed in the `redirectsFile` field.
 
 Each object in the `redirects` array has 2 important keys: `from` and `to`.
 

--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ module.exports = {
       var conf = JSON.parse(fs.readFileSync(redirectConf.redirectsFile, "utf-8"));
 
       if (!conf || !conf.redirects) return;
+      if (this.isLanguageBook()) return;
 
       var basepath = redirectConf.basepath || "/";
       var g = this;

--- a/index.js
+++ b/index.js
@@ -42,8 +42,13 @@ module.exports = {
 
       conf.redirects.forEach(function (item) {
         if (!item.from || !item.to) return;
-        var resolved = url.resolve(basepath, item.to);
-        g.output.writeFile(item.from, content(resolved));
+        if (item.from.endsWith('/')) {
+          var resolved = url.resolve(basepath, '/../' + item.to);
+          g.output.writeFile(item.from + '/index.html', content(resolved));
+        } else {
+          var resolved = url.resolve(basepath, item.to);
+          g.output.writeFile(item.from, content(resolved));
+        }
         g.log.debug("Redirect " + item.from + " -> " + resolved + "\n");
       });
     }

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ module.exports = {
       if (!conf || !conf.redirects) return;
       if (this.isLanguageBook()) return;
 
-      var basepath = redirectConf.basepath || "/";
+      var basepath = redirectConf.basepath === undefined ? "/" : redirectConf.basepath
       var g = this;
 
       conf.redirects.forEach(function (item) {

--- a/index.js
+++ b/index.js
@@ -17,13 +17,19 @@
 var url = require("url");
 var fs = require("fs");
 
-var content = function(path) {
-  var s = "<!DOCTYPE HTML><html><head><meta charset='UTF-8'><title>Redirecting... Page moved</title>" +
-        "<link rel='canonical' href='{}'><meta http-equiv=refresh content='0; url={:?}'></head>" +
-        "<body><h1>Redirecting... Page moved...</h1>" +
-        "<p><a href='{}'>Click here if you are not redirected</a></p>" +
-        "<script>window.location.href='{}';</script>" +
-        "</body></html>";
+var content = function(path, blank) {
+  if (blank) {
+    var s = "<!DOCTYPE HTML><html><head><meta charset='UTF-8'>" +
+          "<link rel='canonical' href='{}'><meta http-equiv=refresh content='0; url={:?}'>" +
+          "<script>window.location.href='{}'</script></head></html>";
+  } else {
+    var s = "<!DOCTYPE HTML><html><head><meta charset='UTF-8'>" +
+          "<link rel='canonical' href='{}'><meta http-equiv=refresh content='0; url={:?}'></head>" +
+          "<body><h1>Redirecting... Page moved...</h1>" +
+          "<p><a href='{}'>Click here if you are not redirected</a></p>" +
+          "<script>window.location.href='{}';</script>" +
+          "</body></html>";
+  }
   return s.replace(/\{\}/gm, path).replace(/\{\:\?\}/gm, encodeURI(path));
 };
 
@@ -44,10 +50,10 @@ module.exports = {
         if (!item.from || !item.to) return;
         if (item.from.endsWith('/')) {
           var resolved = url.resolve(basepath, '/../' + item.to);
-          g.output.writeFile(item.from + '/index.html', content(resolved));
+          g.output.writeFile(item.from + '/index.html', content(resolved, redirectConf.blank));
         } else {
           var resolved = url.resolve(basepath, item.to);
-          g.output.writeFile(item.from, content(resolved));
+          g.output.writeFile(item.from, content(resolved, redirectConf.blank));
         }
         g.log.debug("Redirect " + item.from + " -> " + resolved + "\n");
       });


### PR DESCRIPTION
This plugin applies recursively to all the languages subbooks, which creates infinite redirects.

I disabled plugin for subbooks.

Fixes #3.